### PR TITLE
Fix/embeds and array

### DIFF
--- a/lib/para.ex
+++ b/lib/para.ex
@@ -454,10 +454,6 @@ defmodule Para do
   end
 
   @doc false
-  def apply_changes(list) when is_list(list) do
-    Enum.map(list, &apply_changes/1)
-  end
-
   def apply_changes(%{changes: changes, data: data}) do
     Enum.reduce(changes, data, fn
       {key, list}, acc when is_list(list) ->
@@ -470,4 +466,10 @@ defmodule Para do
         Map.put(acc, key, value)
     end)
   end
+
+  def apply_changes(list) when is_list(list) do
+    Enum.map(list, &apply_changes/1)
+  end
+
+  def apply_changes(any), do: any
 end

--- a/lib/para.ex
+++ b/lib/para.ex
@@ -409,6 +409,8 @@ defmodule Para do
             )
         end
       end)
+    else
+      changeset
     end
   end
 

--- a/test/para_test.exs
+++ b/test/para_test.exs
@@ -141,6 +141,11 @@ defmodule ParaTest do
             }} = EmbedsManyPara.validate(:test, params)
   end
 
+  test "it validates empty embeds_many params" do
+    params = %{"title" => "test", "products" => nil}
+    assert {:ok, %{title: "test", products: nil}} = EmbedsManyPara.validate(:test, params)
+  end
+
   test "it rejects invalid embeds_many params" do
     invalid_params = %{
       "title" => "test",

--- a/test/para_test.exs
+++ b/test/para_test.exs
@@ -194,4 +194,21 @@ defmodule ParaTest do
     assert {:ok, %{children: [%{full_name: "Eli Ji"}, %{full_name: "Fang XY"}]}} =
              EmbedsManyWithCallback.validate(:test, params)
   end
+
+  defmodule ArrayMapPara do
+    use Para
+
+    validator :test do
+      required :data, {:array, :map}
+      required :list, {:array, :string}
+    end
+  end
+
+  test "it validates arrays and returns original data" do
+    data = [%{"foo" => "bar"}, %{"baz" => "qux"}]
+    list = ["one", "two"]
+    params = %{"data" => data, "list" => list}
+
+    assert {:ok, %{data: ^data, list: ^list}} = ArrayMapPara.validate(:test, params)
+  end
 end


### PR DESCRIPTION
1. Fixed `embeds_many/2` - when key for an `embeds_many` field is empty, return the original changeset instead of `nil`
2. Fixed validation for array datatype - correctly parse, validate and return the original data submitted to array datatype fields (e.g. `{:array, :map}`)
