### PR TITLE
Add spec/2 callback function

### DIFF
--- a/lib/para.ex
+++ b/lib/para.ex
@@ -69,17 +69,18 @@ defmodule Para do
       end
 
   You can also use custom inline validators by supplying the function name
-  as an atom. Custom inline validator will receive `changeset` and the
-  original `params` as the arguments.
+  as an atom. Similar to most Ecto's built-in validators, the function will
+  receive `changeset`, `key`, and `opts` as the arguments.
 
       defmodule UserPara do
         use Para
 
         validator :update do
           required :age, :string, validator: :validate_age
+          required :gender, :string, validator: {:validate_gender, [allow: :non_binary]}
         end
 
-        def validate_age(changeset, params) do
+        def validate_age(changeset, key, opts) do
           # ...
         end
       end

--- a/test/para_test.exs
+++ b/test/para_test.exs
@@ -261,4 +261,35 @@ defmodule ParaTest do
       assert %{errors: [url: {"invalid URL", []}, another_url: {"invalid host", []}]} = error
     end
   end
+
+  defmodule SpecPara do
+    use Para
+
+    validator :test do
+      required :title, :string
+
+      embeds_one :product do
+        required :name
+        required :price, :float
+      end
+    end
+  end
+
+  test "it builds spec for changeset" do
+    spec = SpecPara.spec(:test, %{})
+
+    assert %{
+             data: %{product: nil, title: nil},
+             embeds: %{
+               product:
+                 {:embed_one, [{:required, :name, :string, []}, {:required, :price, :float, []}]}
+             },
+             permitted: [:title],
+             required: [:title],
+             types: %{product: {:map, :string}, title: :string},
+             validators: %{}
+           } = spec
+
+    assert %Ecto.Changeset{} = Ecto.Changeset.change({spec.data, spec.types}, %{})
+  end
 end


### PR DESCRIPTION
Added `spec/2` callback function.

This is mainly a helper function to build "empty" changesets, where you just need a basic structure of the schema without all the validations. I'm basically dogfooding this for my own project.

The most common place where this might be used is within a `:new` action in a Phoenix controller.

For example, you might have a form that needs a `changeset`, as such: 

```eex
<%= form_for @changeset, ...
```

You can utilise the `spec/2` function to build this changeset:

```elixir
# Provided you've already created a validator for the :create action

def changeset(:new, params) do
  spec = __MODULE__.spec(:create, params)
  Ecto.Changeset.change({spec.data, spec.types})
end
```