### PR TITLE
Fix embeds_one crash on missing or non-map params

### DIFF
--- a/lib/para.ex
+++ b/lib/para.ex
@@ -503,12 +503,16 @@ defmodule Para do
   def validate_embed(changeset, module, name, {:embed_one, block}, params) do
     params = Map.get(params, Atom.to_string(name))
 
-    case do_validate(module, block, params) do
-      %{valid?: true} = valid_changeset ->
-        Ecto.Changeset.put_change(changeset, name, valid_changeset)
+    if is_map(params) do
+      case do_validate(module, block, params) do
+        %{valid?: true} = valid_changeset ->
+          Ecto.Changeset.put_change(changeset, name, valid_changeset)
 
-      invalid_changeset ->
-        Ecto.Changeset.put_change(%{changeset | valid?: false}, name, invalid_changeset)
+        invalid_changeset ->
+          Ecto.Changeset.put_change(%{changeset | valid?: false}, name, invalid_changeset)
+      end
+    else
+      changeset
     end
   end
 

--- a/test/para_test.exs
+++ b/test/para_test.exs
@@ -125,6 +125,16 @@ defmodule ParaTest do
              EmbedsOneParams.validate(:test, params)
   end
 
+  test "it skips validation when embeds_one key is missing" do
+    params = %{"title" => "test"}
+    assert {:ok, %{title: "test", product: nil}} = EmbedsOneParams.validate(:test, params)
+  end
+
+  test "it skips validation when embeds_one params are nil" do
+    params = %{"title" => "test", "product" => nil}
+    assert {:ok, %{title: "test", product: nil}} = EmbedsOneParams.validate(:test, params)
+  end
+
   defmodule EmbedsManyParams do
     use Para
 


### PR DESCRIPTION
## Summary

`validate_embed/5` for `:embed_one` passed the looked-up value straight into `Ecto.Changeset.cast/3`, which only accepts a `%{}` or `:invalid`. If the embed key was absent from the parent params (so `Map.get/2` returned `nil`) or held a non-map value, validation crashed with `FunctionClauseError` rather than producing a changeset.

The fix guards the lookup with `is_map/1` and skips embed validation otherwise, mirroring the existing `embeds_many` behavior (which already guards with `is_list/1`).

## Behavior

```elixir
defmodule UserParams do
  use Para

  validator :create do
    required :title, :string

    embeds_one :product do
      required :name
      required :price, :float
    end
  end
end

# before: ** (FunctionClauseError) no function clause matching in Ecto.Changeset.cast/4
# after:  {:ok, %{title: "test", product: nil}}
UserParams.validate(:create, %{"title" => "test"})
```

If you need the embed to be required, enforce it in a `callback`; this matches how `embeds_many` already works.

## Test plan

- [ ] CI green on `OTP 25.0.4 / Elixir 1.17.3`
- Added `test/para_test.exs` cases covering the missing-key and explicit-`nil` scenarios for `embeds_one`