### PR TITLE
Support droppable option on embeds_one and embeds_many

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -7,7 +7,9 @@ locals_without_parens = [
   optional: 3,
   callback: 1,
   embeds_one: 2,
-  embeds_many: 2
+  embeds_one: 3,
+  embeds_many: 2,
+  embeds_many: 3
 ]
 
 [

--- a/lib/para.ex
+++ b/lib/para.ex
@@ -207,7 +207,9 @@ defmodule Para do
           optional: 3,
           callback: 1,
           embeds_one: 2,
-          embeds_many: 2
+          embeds_one: 3,
+          embeds_many: 2,
+          embeds_many: 3
         ]
     end
   end
@@ -324,9 +326,14 @@ defmodule Para do
   end
 
   @doc """
-  Define an embedded map field
+  Define an embedded map field.
 
   It accepts similar schema definition like `validator/2`.
+
+  ## Options
+
+    * `:droppable` - Drop the embed when the key doesn't exist in parameters.
+      This is useful for partial updates where the whole embed may be omitted.
 
   ## Examples
 
@@ -340,8 +347,18 @@ defmodule Para do
           end
         end
       end
+
+      defmodule ParentParams do
+        use Para
+
+        validator :update do
+          embeds_one :child, droppable: true do
+            optional :name, :string
+          end
+        end
+      end
   """
-  defmacro embeds_one(name, do: block) do
+  defmacro embeds_one(name, opts \\ [], do: block) do
     fields =
       case block do
         {:__block__, _, fields} -> fields
@@ -349,7 +366,7 @@ defmodule Para do
       end
 
     quote do
-      {:embed_one, unquote(name), unquote(fields)}
+      {:embed_one, unquote(name), unquote(fields), unquote(opts)}
     end
   end
 
@@ -357,6 +374,11 @@ defmodule Para do
   Define an embedded array of maps field.
 
   It accepts similar schema definition like `validator/2`.
+
+  ## Options
+
+    * `:droppable` - Drop the embed when the key doesn't exist in parameters.
+      This is useful for partial updates where the whole embed may be omitted.
 
   ## Examples
 
@@ -370,8 +392,19 @@ defmodule Para do
           end
         end
       end
+
+      defmodule OrderParams do
+        use Para
+
+        validator :update do
+          embeds_many :items, droppable: true do
+            required :title
+            required :price, :float
+          end
+        end
+      end
   """
-  defmacro embeds_many(name, do: block) do
+  defmacro embeds_many(name, opts \\ [], do: block) do
     fields =
       case block do
         {:__block__, _, fields} -> fields
@@ -379,7 +412,7 @@ defmodule Para do
       end
 
     quote do
-      {:embed_many, unquote(name), unquote(fields)}
+      {:embed_many, unquote(name), unquote(fields), unquote(opts)}
     end
   end
 
@@ -416,13 +449,13 @@ defmodule Para do
     fields
     |> discard_droppable_fields(params)
     |> Enum.reduce(default, fn
-      {:embed_one, name, block}, acc ->
+      {:embed_one, name, block, _opts}, acc ->
         acc
         |> put_in([:data, name], nil)
         |> put_in([:embeds, name], {:embed_one, block})
         |> put_in([:types, name], {:map, :string})
 
-      {:embed_many, name, block}, acc ->
+      {:embed_many, name, block, _opts}, acc ->
         acc
         |> put_in([:data, name], nil)
         |> put_in([:embeds, name], {:embed_many, block})
@@ -446,17 +479,7 @@ defmodule Para do
   @doc false
   def discard_droppable_fields(fields, params) do
     Enum.filter(fields, fn
-      # optional/required fields
-      {_, name, _, opts} ->
-        with true <- opts[:droppable],
-             false <- Map.has_key?(params, Atom.to_string(name)) do
-          false
-        else
-          _ -> true
-        end
-
-      # embed fields
-      {_, name, opts} ->
+      {_, name, _, opts} when is_list(opts) ->
         with true <- opts[:droppable],
              false <- Map.has_key?(params, Atom.to_string(name)) do
           false

--- a/test/para_test.exs
+++ b/test/para_test.exs
@@ -341,6 +341,63 @@ defmodule ParaTest do
     assert {:ok, ^params} = result
   end
 
+  defmodule DroppableEmbedsParams do
+    use Para
+
+    validator :update do
+      required :name, :string
+
+      embeds_one :address, droppable: true do
+        required :street, :string
+        required :city, :string
+      end
+
+      embeds_many :tags, droppable: true do
+        required :label, :string
+      end
+    end
+  end
+
+  describe "droppable embeds_one" do
+    test "drops the embed when the key is missing" do
+      params = %{"name" => "Alice"}
+      assert {:ok, result} = DroppableEmbedsParams.validate(:update, params)
+      assert result == %{name: "Alice"}
+    end
+
+    test "validates the embed when the key is present" do
+      params = %{
+        "name" => "Alice",
+        "address" => %{"street" => "1 Main", "city" => "Springfield"}
+      }
+
+      assert {:ok, %{name: "Alice", address: %{street: "1 Main", city: "Springfield"}}} =
+               DroppableEmbedsParams.validate(:update, params)
+    end
+
+    test "rejects the embed when its required fields are missing" do
+      params = %{"name" => "Alice", "address" => %{"street" => "1 Main"}}
+
+      assert {:error, %{changes: %{address: %{errors: [city: {"can't be blank", _}]}}}} =
+               DroppableEmbedsParams.validate(:update, params)
+    end
+  end
+
+  describe "droppable embeds_many" do
+    test "drops the embed when the key is missing" do
+      params = %{"name" => "Alice"}
+      assert {:ok, result} = DroppableEmbedsParams.validate(:update, params)
+      refute Map.has_key?(result, :tags)
+    end
+
+    test "validates the embed when the key is present" do
+      params = %{"name" => "Alice", "tags" => [%{"label" => "vip"}, %{"label" => "beta"}]}
+
+      assert {:ok, %{name: "Alice", tags: [%{label: "vip"}, %{label: "beta"}]}} =
+               DroppableEmbedsParams.validate(:update, params)
+    end
+  end
+
   @doc """
   A helper that transforms changeset errors into a map of messages.
 


### PR DESCRIPTION
## Summary

The `:droppable` option is documented on `required/3` and works there, but until now it silently did nothing on embeds — the embed macros emitted a 3-tuple whose third element was the inner block, not an opts keyword list, so the embed clause in `discard_droppable_fields/2` could never see `opts[:droppable]`.

This PR wires it up properly:

- `embeds_one/2` and `embeds_many/2` now also accept an `opts` keyword list (`embeds_one/3`, `embeds_many/3`), emitting a 4-tuple `{tag, name, block, opts}`. The shape mirrors `required/optional`, so the existing 4-tuple branch in `discard_droppable_fields/2` covers both kinds and the previous dead embed-specific branch can go.
- `__using__` and `.formatter.exs` learn the new arities.
- Docstrings for both macros document the option.

## Behavior

```elixir
defmodule UserParams do
  use Para

  validator :update do
    required :name, :string

    embeds_one :address, droppable: true do
      required :street, :string
      required :city, :string
    end
  end
end

# Embed omitted: dropped entirely, no error.
UserParams.validate(:update, %{"name" => "Alice"})
#=> {:ok, %{name: "Alice"}}

# Embed present but invalid: still validated, errors surface.
UserParams.validate(:update, %{"name" => "Alice", "address" => %{"street" => "1 Main"}})
#=> {:error, %Ecto.Changeset{...}}
```

## Compatibility

- `embeds_one :name do ... end` / `embeds_many :name do ... end` keep working unchanged (`opts` defaults to `[]`).
- The `spec/2` output is unchanged — `spec.embeds[name]` is still `{:embed_one, block}` / `{:embed_many, block}`.

## Test plan

- [x] CI green on `OTP 25.0.4 / Elixir 1.17.3`
- Added `describe` blocks for `droppable embeds_one` and `droppable embeds_many` in `test/para_test.exs`:
  - drops embed when key is absent
  - validates embed when key is present
  - rejects embed when its inner required fields are missing

---
_Generated by [Claude Code](https://claude.ai/code/session_01UtBE3DAWtqp9zpna4XQaUS)_